### PR TITLE
Add GitHub Actions workflow for CI/CD with S3 deployment and CloudFro…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy Static Website to S3
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::626690050115:role/GitHubOIDCDeployRole
+          aws-region: eu-west-2  # or your region
+
+      - name: Sync files to S3
+        run: |
+          aws s3 sync ./public s3://static-web-p1 --delete
+
+      - name: Invalidate CloudFront Cache
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id EJBUR7HZUTBV0 \
+            --paths "/*"


### PR DESCRIPTION
…nt cache invalidation

"Add GitHub Actions workflow": Clearly indicates you're adding a new workflow file.

"for CI/CD": Shows the purpose of the workflow (Continuous Integration and Continuous Deployment).

"with S3 deployment and CloudFront cache invalidation": Specifies the main tasks the workflow will handle (deploying to S3 and invalidating CloudFront).